### PR TITLE
Move deps back to dev-2.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 ]}.
 
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/nhs-riak/riak_pb.git", {branch, "rdb/2.2.0.0-nhs-2.2.5"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}}
 ]}.
 
 {edoc_opts, [

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 ]}.
 
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}}
+        {riak_pb, ".*", {git, "git://github.com/nhs-riak/riak_pb.git", {branch, "develop-2.2"}}}
 ]}.
 
 {edoc_opts, [

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 ]}.
 
 {deps, [
-    {riak_pb, ".*", {git, "https://github.com/basho/riak_pb", {tag, "2.2.0.0"}}}
+        {riak_pb, ".*", {git, "git://github.com/nhs-riak/riak_pb.git", {branch, "rdb/2.2.0.0-nhs-2.2.5"}}}
 ]}.
 
 {edoc_opts, [

--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -112,12 +112,14 @@ module_for_term(T) ->
                    prop_module_for_term]).
 -define(F(Fmt, Args), lists:flatten(io_lib:format(Fmt, Args))).
 datatypes_test_() ->
+    {timeout, 120,
      [{" prop_module_type() ",
        ?_assert(eqc:quickcheck(?QC_OUT(prop_module_type())))}] ++
-     [ {?F(" ~s(~s) ", [Prop, Mod]),
-        ?_assert(eqc:quickcheck(?QC_OUT(eqc:testing_time(2, ?MODULE:Prop(Mod)))))} ||
-         Prop <- ?MODPROPS,
-         Mod <- ?MODULES ].
+         [ {?F(" ~s(~s) ", [Prop, Mod]),
+            ?_assert(eqc:quickcheck(?QC_OUT(eqc:testing_time(2, ?MODULE:Prop(Mod)))))} ||
+             Prop <- ?MODPROPS,
+             Mod <- ?MODULES ]
+    }.
 
 run_props() ->
     run_props(500).


### PR DESCRIPTION
As part of setting up for the 2.2.5 release I made a temp branch off the
last released tag, this takes that branch back into the branch the tag
was cut from.